### PR TITLE
add latest tag for konflux build

### DIFF
--- a/.tekton/jenkins-mcp-push.yaml
+++ b/.tekton/jenkins-mcp-push.yaml
@@ -533,6 +533,9 @@ spec:
       params:
       - name: IMAGE_URL
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value: 
+          - latest
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       runAfter:


### PR DESCRIPTION
What?
Currently there is no latest tagged image in https://quay.io/repository/redhat-ai-tools/jenkins-mcp?tab=tags
So while configuring jenkins-mcp in any agent `quay.io/redhat-ai-tools/jenkins-mcp:latest` won't work. 
To make it work in current environment either one needs to specify hash or specific tag.
 
How:
This configuration will add a latest tag for latest build. 