### PR TITLE
feat: Load environment variables from .env file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,15 @@
+# Jenkins-MCP configuration
+#
+# Copy this file to .env and fill in the values.
+#
+# The server will load environment variables from the .env file.
+# Environment variables set in the shell will take precedence.
+
+# Jenkins URL (e.g., https://jenkins.example.com/)
+JENKINS_URL=
+
+# Jenkins API token
+JENKINS_TOKEN=
+
+# MCP transport (stdio or sse)
+MCP_TRANSPORT=stdio

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 venv/
+.env

--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@ MCP Server for multiple Jenkins instances
 
 ## Overview
 
-This MCP (Model Context Protocol) server allows you to interact with multiple Jenkins instances from a single server. Unlike traditional setups, this server extracts the Jenkins URL and API token from each request's headers, enabling true multi-tenancy.
+This MCP (Model Context Protocol) server allows you to interact with multiple Jenkins instances from a single server. Unlike traditional setups, this server extracts the Jenkins URL and an API token from each request's headers, enabling true multi-tenancy.
 
 - **Multi-tenancy**: Serve multiple Jenkins instances from a single MCP server.
 - **Header-based authentication**: Jenkins URL and token are provided per request via headers.
 - **Parity with official Jenkins MCP plugin**: Implements the same core tools as the [official Jenkins MCP Server Plugin](https://plugins.jenkins.io/mcp-server/).
+
+### .env File Support
+The server can load configuration from a `.env` file in the project root. This is useful for development or when running the server outside of a container. A `.env.sample` file is provided as a template.
+
+Environment variables set in your shell will take precedence over values in the `.env` file.
 
 ## Running the Jenkins MCP Server
 

--- a/jenkins_mcp_server.py
+++ b/jenkins_mcp_server.py
@@ -1,7 +1,10 @@
 import os
 from typing import Any, Optional
 import httpx
+from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+
+load_dotenv()
 
 mcp = FastMCP("jenkins")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 httpx==0.28.1
 mcp==1.11.0
+python-dotenv


### PR DESCRIPTION
Thank you for this MCP server!

Because I have mine `.gemini/settings.json` in git, I do not want to have secrets there. This way I can have all the secrets (and other env variables) in `.env` file and only have this in AI agent config:

```
{
  "mcpServers": {
    "jenkins-mcp": {
      "command": "uv",
      "args": [
        "run",
        "jenkins_mcp_server.py"
      ],
      "cwd": "/home/jhutar/Checkouts/jenkins-mcp/"
    }
  }
}
```

For completeness, `uv` environment was created with `uv init; uv pip install -r requirements.txt`.