### PR TITLE
fix: Auth, build log parsing, nested job paths + new tools

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -7,24 +7,56 @@ MCP Server for multiple Jenkins instances
 This MCP (Model Context Protocol) server allows you to interact with multiple Jenkins instances from a single server. Unlike traditional setups, this server extracts the Jenkins URL and an API token from each request's headers, enabling true multi-tenancy.
 
 - **Multi-tenancy**: Serve multiple Jenkins instances from a single MCP server.
-- **Header-based authentication**: Jenkins URL and token are provided per request via headers.
-- **Parity with official Jenkins MCP plugin**: Implements the same core tools as the [official Jenkins MCP Server Plugin](https://plugins.jenkins.io/mcp-server/).
+- **Header-based authentication**: Jenkins URL, username, and token are provided per request via headers.
+- **Parity with official Jenkins MCP plugin**: Implements the same core tools as the [official Jenkins MCP Server Plugin](https://plugins.jenkins.io/mcp-server/), plus additional tools for pipeline and build analysis.
 
-### .env File Support
-The server can load configuration from a `.env` file in the project root. This is useful for development or when running the server outside of a container. A `.env.sample` file is provided as a template.
+### Credential Loading (Priority Order)
 
-Environment variables set in your shell will take precedence over values in the `.env` file.
+1. **`~/.jenkins/config.json`** file (if it exists)
+2. **`.env`** file in the project root (via python-dotenv)
+3. **Environment variables** (`JENKINS_URL`, `JENKINS_USER`, `JENKINS_TOKEN`)
+4. **Request headers** (non-stdio mode only: `Jenkins-Url`, `Jenkins-User`, `Jenkins-Token`)
 
 ## Running the Jenkins MCP Server
 
 You can run the server with either `stdio` (for local/CLI use) or a network transport (e.g., SSE for remote clients).
 
 ### Environment Variables (stdio mode)
-- `JENKINS_URL`: The Jenkins instance URL (used only in stdio mode)
-- `JENKINS_TOKEN`: The Jenkins API token (used only in stdio mode)
+- `JENKINS_URL`: The Jenkins instance URL
+- `JENKINS_USER`: The Jenkins username (for HTTP Basic auth)
+- `JENKINS_TOKEN`: The Jenkins API token
 - `MCP_TRANSPORT`: Set to `stdio` (default) or another transport (e.g., `sse`)
 
-#### Example MCP Client Configuration
+#### Using `~/.jenkins/config.json`
+
+```json
+{
+  "jenkins_url": "https://jenkins.example.com",
+  "jenkins_user": "your-username",
+  "jenkins_token": "your-api-token"
+}
+```
+
+#### Example MCP Client Configuration (stdio)
+
+```json
+{
+  "mcpServers": {
+    "jenkins": {
+      "command": "python",
+      "args": ["jenkins_mcp_server.py"],
+      "env": {
+        "JENKINS_URL": "https://jenkins.example.com/",
+        "JENKINS_USER": "your-username",
+        "JENKINS_TOKEN": "REDACTED",
+        "MCP_TRANSPORT": "stdio"
+      }
+    }
+  }
+}
+```
+
+#### Example MCP Client Configuration (container)
 
 ```json
 {
@@ -36,12 +68,14 @@ You can run the server with either `stdio` (for local/CLI use) or a network tran
         "-i",
         "--rm",
         "-e", "JENKINS_URL",
+        "-e", "JENKINS_USER",
         "-e", "JENKINS_TOKEN",
         "-e", "MCP_TRANSPORT",
         "quay.io/redhat-ai-tools/jenkins-mcp:latest"
       ],
       "env": {
         "JENKINS_URL": "https://jenkins.example.com/",
+        "JENKINS_USER": "your-username",
         "JENKINS_TOKEN": "REDACTED",
         "MCP_TRANSPORT": "stdio"
       }
@@ -53,8 +87,9 @@ You can run the server with either `stdio` (for local/CLI use) or a network tran
 Replace `REDACTED` with your Jenkins API token, which you can generate from your Jenkins user account settings.
 
 ### Header-based Authentication (non-stdio mode)
-For non-stdio transports, the Jenkins URL and token must be provided in each request's headers:
+For non-stdio transports, credentials can be provided in each request's headers:
 - `Jenkins-Url`: The Jenkins instance URL
+- `Jenkins-User`: The Jenkins username
 - `Jenkins-Token`: The Jenkins API token
 
 This allows the server to route requests to different Jenkins instances per client/request.
@@ -68,6 +103,7 @@ This allows the server to route requests to different Jenkins instances per clie
       "url": "https://jenkins-mcp.example.com/sse",
       "headers": {
         "Jenkins-Url": "https://jenkins.example.com/",
+        "Jenkins-User": "your-username",
         "Jenkins-Token": "REDACTED"
       }
     }
@@ -77,18 +113,51 @@ This allows the server to route requests to different Jenkins instances per clie
 
 ## Available Tools
 
-The following tools are implemented, matching the official Jenkins MCP plugin:
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `get_all_jobs` | — | List all jobs at root level with name, URL, and status |
+| `get_job` | `job_path` | Get details for a job by slash-separated path |
+| `get_build` | `job_path`, `build_number?` | Get build info (specific number or last build) |
+| `trigger_build` | `job_path`, `parameters?` | Trigger a build, optionally with parameters |
+| `get_build_log` | `job_path`, `build_number?`, `start?`, `max_lines?` | Get console output (plain text, paginated, truncated) |
+| `get_build_status` | `build_url` | Quick status check from a full build URL |
+| `get_pipeline_stages` | `job_path`, `build_number?` | Get pipeline stage names, statuses, durations via Workflow API |
 
-- `getAllJobs`: Get a list of all Jenkins jobs.
-- `getJob(full_path)`: Get a Jenkins job by its full path.
-- `getBuild(full_path, build_number=None)`: Retrieve a specific build or the last build of a Jenkins job.
-- `triggerBuild(full_path)`: Trigger a build of a job.
-- `getBuildLog(full_path, build_number=None, start=0)`: Retrieve log lines for a specific build or the last build of a Jenkins job (supports pagination).
+### Job Path Format
+
+Jobs are referenced using slash-separated paths. The server handles conversion to the Jenkins API format automatically:
+
+```
+# Input                          -> Jenkins API path
+"my-job"                         -> "job/my-job"
+"folder/subfolder/my-job"        -> "job/folder/job/subfolder/job/my-job"
+"job/already/job/formatted"      -> "job/already/job/formatted"  (unchanged)
+```
 
 ## Usage
 
-- For each request, provide the Jenkins URL and token in the headers (unless using stdio mode, where they are read from environment variables).
-- The server will use these credentials to interact with the specified Jenkins instance.
+```python
+# List all jobs
+get_all_jobs()
+
+# Get a specific job (nested folder support)
+get_job("qe-acm-automation-poc/clc-e2e-pipeline")
+
+# Get the last build
+get_build("qe-acm-automation-poc/clc-e2e-pipeline")
+
+# Trigger a build with parameters
+trigger_build("my-folder/my-job", parameters={"BRANCH": "main", "ENV": "staging"})
+
+# Get build log (last 500 lines)
+get_build_log("qe-acm-automation-poc/clc-e2e-pipeline", build_number=3913)
+
+# Quick status check from URL
+get_build_status("https://jenkins.example.com/job/CI/job/main/42/")
+
+# Pipeline stage details
+get_pipeline_stages("qe-acm-automation-poc/clc-e2e-pipeline", build_number=3913)
+```
 
 ## References
 - [Official Jenkins MCP Server Plugin](https://plugins.jenkins.io/mcp-server/)

--- a/jenkins_mcp_server.py
+++ b/jenkins_mcp_server.py
@@ -1,91 +1,246 @@
+import json
 import os
+import re
+import urllib3
+from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlparse
+
 import httpx
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
 
 load_dotenv()
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 mcp = FastMCP("jenkins")
 
 MCP_TRANSPORT = os.environ.get("MCP_TRANSPORT", "stdio")
+JENKINS_CONFIG_PATH = Path.home() / ".jenkins" / "config.json"
 
 
-def get_jenkins_context() -> tuple[str, str]:
-    ctx = mcp.get_context().request_context.request
-    jenkins_url = (
-        os.environ["JENKINS_URL"]
-        if MCP_TRANSPORT == "stdio"
-        else ctx.headers["Jenkins-Url"]
-    )
-    jenkins_token = (
-        os.environ["JENKINS_TOKEN"]
-        if MCP_TRANSPORT == "stdio"
-        else ctx.headers["Jenkins-Token"]
-    )
+def _load_file_config() -> dict:
+    """Load credentials from ~/.jenkins/config.json if it exists."""
+    if JENKINS_CONFIG_PATH.exists():
+        with open(JENKINS_CONFIG_PATH) as f:
+            return json.load(f)
+    return {}
+
+
+_file_cfg = _load_file_config()
+
+
+def get_jenkins_context() -> tuple[str, str, str]:
+    """Get Jenkins URL, username, and token for the current request.
+
+    In stdio mode, reads from ~/.jenkins/config.json, .env file, or env vars.
+    In network mode, reads from request headers with env/file fallback.
+    """
+    if MCP_TRANSPORT == "stdio":
+        jenkins_url = _file_cfg.get("jenkins_url", "") or os.environ.get("JENKINS_URL", "")
+        jenkins_user = _file_cfg.get("jenkins_user", "") or os.environ.get("JENKINS_USER", "")
+        jenkins_token = _file_cfg.get("jenkins_token", "") or os.environ.get("JENKINS_TOKEN", "")
+    else:
+        ctx = mcp.get_context().request_context.request
+        jenkins_url = ctx.headers.get("Jenkins-Url", "") or _file_cfg.get("jenkins_url", "") or os.environ.get("JENKINS_URL", "")
+        jenkins_user = ctx.headers.get("Jenkins-User", "") or _file_cfg.get("jenkins_user", "") or os.environ.get("JENKINS_USER", "")
+        jenkins_token = ctx.headers.get("Jenkins-Token", "") or _file_cfg.get("jenkins_token", "") or os.environ.get("JENKINS_TOKEN", "")
+
     if not jenkins_url or not jenkins_token:
-        raise Exception("Missing Jenkins URL or Token in headers")
-    return jenkins_url, jenkins_token
+        raise Exception("Missing Jenkins URL or Token")
+    return jenkins_url.rstrip("/"), jenkins_user, jenkins_token
 
 
-async def jenkins_api_call(
-    api_path: str, method: str = "GET", data: dict[str, Any] = None
-) -> dict[str, Any] | None:
-    async with httpx.AsyncClient(verify=False) as client:
-        jenkins_url, jenkins_token = get_jenkins_context()
-        url = f"{jenkins_url.rstrip('/')}/{api_path.lstrip('/')}"
-        headers = {
-            "Authorization": f"Bearer {jenkins_token}",
-            "Accept": "application/json",
-        }
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def normalize_job_path(job_path: str) -> str:
+    """Convert slash-separated path to Jenkins API format.
+
+    'folder/sub/job' -> 'job/folder/job/sub/job/job'
+    Paths already containing 'job/' segments are returned as-is.
+    """
+    if not job_path:
+        return job_path
+    job_path = job_path.strip("/")
+    if job_path.startswith("job/"):
+        return job_path
+    parts = job_path.split("/")
+    return "/".join(f"job/{p}" for p in parts)
+
+
+def parse_jenkins_url(url: str) -> tuple[str, str, Optional[int]]:
+    """Parse a full Jenkins build URL into (base_url, job_api_path, build_number).
+
+    Example:
+        https://jenkins.example.com/job/CI/job/main/42/
+        -> ("https://jenkins.example.com", "job/CI/job/main", 42)
+    """
+    parsed = urlparse(url.rstrip("/"))
+    path = parsed.path.rstrip("/")
+
+    build_number: Optional[int] = None
+    segments = path.split("/")
+    if segments and segments[-1].isdigit():
+        build_number = int(segments[-1])
+        segments = segments[:-1]
+
+    path_str = "/".join(segments)
+    match = re.search(r"(/?job/.+)$", path_str)
+    job_api_path = match.group(1).lstrip("/") if match else ""
+
+    base_url = f"{parsed.scheme}://{parsed.netloc}"
+    return base_url, job_api_path, build_number
+
+
+async def jenkins_api(
+    api_path: str,
+    method: str = "GET",
+    data: dict[str, Any] | None = None,
+    expect_json: bool = True,
+) -> dict[str, Any] | str | None:
+    """Authenticated Jenkins API call.
+
+    Uses HTTP Basic auth when jenkins_user is available (standard Jenkins API
+    token flow), otherwise falls back to Bearer token.
+    """
+    jenkins_url, jenkins_user, jenkins_token = get_jenkins_context()
+
+    auth = None
+    extra_headers: dict[str, str] = {}
+    if jenkins_user:
+        auth = httpx.BasicAuth(jenkins_user, jenkins_token)
+    else:
+        extra_headers["Authorization"] = f"Bearer {jenkins_token}"
+    if expect_json:
+        extra_headers["Accept"] = "application/json"
+
+    async with httpx.AsyncClient(verify=False, auth=auth, timeout=60.0) as client:
+        url = f"{jenkins_url}/{api_path.lstrip('/')}"
         if method.upper() == "GET":
-            response = await client.request(method, url, headers=headers, params=data)
+            resp = await client.request(method, url, headers=extra_headers, params=data)
         else:
-            response = await client.request(method, url, headers=headers, json=data)
-        response.raise_for_status()
-        return response.json()
+            resp = await client.request(method, url, headers=extra_headers, data=data)
+        resp.raise_for_status()
+        return resp.json() if expect_json else resp.text
+
+
+# ------------------------------------------------------------------
+# Tools
+# ------------------------------------------------------------------
 
 
 @mcp.tool()
-async def getAllJobs() -> Any:
-    """Get a list of all Jenkins jobs."""
-    return await jenkins_api_call("api/json")
+async def get_all_jobs() -> Any:
+    """List all Jenkins jobs at the root level with name, URL, and status color."""
+    return await jenkins_api("api/json?tree=jobs[name,url,color]")
 
 
 @mcp.tool()
-async def getJob(full_path: str) -> Any:
-    """Get a Jenkins job by its full path."""
-    return await jenkins_api_call(f"job/{full_path}/api/json")
+async def get_job(job_path: str) -> Any:
+    """Get details for a Jenkins job.
+
+    Args:
+        job_path: Slash-separated path (e.g. 'folder/subfolder/my-job').
+    """
+    return await jenkins_api(f"{normalize_job_path(job_path)}/api/json")
 
 
 @mcp.tool()
-async def getBuild(full_path: str, build_number: Optional[int] = None) -> Any:
-    """Retrieve a specific build or the last build of a Jenkins job."""
-    if build_number is not None:
-        endpoint = f"job/{full_path}/{build_number}/api/json"
+async def get_build(job_path: str, build_number: Optional[int] = None) -> Any:
+    """Get build information for a Jenkins job.
+
+    Args:
+        job_path: Slash-separated path.
+        build_number: Build number, or omit for last build.
+    """
+    base = normalize_job_path(job_path)
+    suffix = f"/{build_number}" if build_number is not None else "/lastBuild"
+    return await jenkins_api(f"{base}{suffix}/api/json")
+
+
+@mcp.tool()
+async def trigger_build(
+    job_path: str,
+    parameters: Optional[dict[str, str]] = None,
+) -> str:
+    """Trigger a Jenkins build, optionally with parameters.
+
+    Args:
+        job_path: Slash-separated path.
+        parameters: Build parameters as key-value pairs.
+    """
+    base = normalize_job_path(job_path)
+    if parameters:
+        await jenkins_api(f"{base}/buildWithParameters", method="POST", data=parameters, expect_json=False)
     else:
-        endpoint = f"job/{full_path}/lastBuild/api/json"
-    return await jenkins_api_call(endpoint)
+        await jenkins_api(f"{base}/build", method="POST", expect_json=False)
+    return f"Build triggered: {job_path}"
 
 
 @mcp.tool()
-async def triggerBuild(full_path: str) -> str:
-    """Trigger a build of a job."""
-    await jenkins_api_call(f"job/{full_path}/build", method="POST")
-    return f"Build triggered for job: {full_path}"
+async def get_build_log(
+    job_path: str,
+    build_number: Optional[int] = None,
+    start: int = 0,
+    max_lines: int = 500,
+) -> str:
+    """Get console output for a build as plain text.
+
+    Args:
+        job_path: Slash-separated path.
+        build_number: Build number, or omit for last build.
+        start: Byte offset for pagination.
+        max_lines: Max lines to return (default 500, 0 for unlimited).
+    """
+    base = normalize_job_path(job_path)
+    suffix = f"/{build_number}" if build_number is not None else "/lastBuild"
+    text = await jenkins_api(
+        f"{base}{suffix}/consoleText", data={"start": start}, expect_json=False,
+    )
+    if not isinstance(text, str):
+        return str(text)
+    if max_lines > 0:
+        lines = text.split("\n")
+        if len(lines) > max_lines:
+            return (
+                "\n".join(lines[-max_lines:])
+                + f"\n\n[Truncated: showing last {max_lines} of {len(lines)} lines]"
+            )
+    return text
 
 
 @mcp.tool()
-async def getBuildLog(
-    full_path: str, build_number: Optional[int] = None, start: int = 0
+async def get_build_status(build_url: str) -> Any:
+    """Quick status check from a full Jenkins build URL.
+
+    Args:
+        build_url: Full Jenkins build URL (e.g. https://jenkins.example.com/job/CI/job/main/42/).
+    """
+    _, job_api_path, build_number = parse_jenkins_url(build_url)
+    suffix = f"/{build_number}" if build_number else "/lastBuild"
+    return await jenkins_api(
+        f"{job_api_path}{suffix}/api/json"
+        "?tree=result,building,duration,estimatedDuration,displayName,timestamp",
+    )
+
+
+@mcp.tool()
+async def get_pipeline_stages(
+    job_path: str,
+    build_number: Optional[int] = None,
 ) -> Any:
-    """Retrieve log lines for a specific build or the last build of a Jenkins job. Supports pagination via 'start'."""
-    if build_number is not None:
-        endpoint = f"job/{full_path}/{build_number}/logText/progressiveText"
-    else:
-        endpoint = f"job/{full_path}/lastBuild/logText/progressiveText"
-    params = {"start": start}
-    return await jenkins_api_call(endpoint, params=params)
+    """Get pipeline stage names, statuses, and durations via the Workflow API.
+
+    Args:
+        job_path: Slash-separated path.
+        build_number: Build number, or omit for last build.
+    """
+    base = normalize_job_path(job_path)
+    suffix = f"/{build_number}" if build_number is not None else "/lastBuild"
+    return await jenkins_api(f"{base}{suffix}/wfapi/describe")
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-httpx==0.28.1
-mcp==1.11.0
+httpx>=0.27.0
+mcp[cli]>=1.1.0
 python-dotenv
+urllib3


### PR DESCRIPTION
## Bug Fixes

### 1. Authentication: Bearer -> HTTP Basic

Jenkins API tokens work with HTTP Basic auth (`username:token` as password), not Bearer tokens. The current `Authorization: Bearer {token}` header does not authenticate against standard Jenkins instances.

**Before:** `Authorization: Bearer {token}` (fails on standard Jenkins)
**After:** `httpx.BasicAuth(username, token)` when username is available, with Bearer fallback for setups that use it

### 2. Build log: JSON parse crash on plain text

`getBuildLog` calls `response.json()` on the `consoleText` endpoint, which returns **plain text**, not JSON. This crashes every time.

**Before:** `response.json()` on plain text -> exception
**After:** `expect_json=False` flag, returns text correctly

### 3. Nested job paths

`job/{full_path}` breaks on nested folder structures. `folder/subfolder/my-job` needs to become `job/folder/job/subfolder/job/my-job` in the Jenkins API.

**Before:** `job/folder/subfolder/my-job` -> 404
**After:** `normalize_job_path()` converts slash-separated paths to proper Jenkins API format

## New Features

| Feature | Description |
|---------|-------------|
| `trigger_build` with parameters | Supports `buildWithParameters` with key-value dict |
| `get_build_log` `max_lines` | Truncates long output (default 500 lines) instead of returning unbounded text |
| `get_build_status` | Parses full Jenkins build URLs, returns quick status (result, building, duration) |
| `get_pipeline_stages` | Workflow API (`wfapi/describe`) for stage names, statuses, and durations |
| `~/.jenkins/config.json` | Alternative credential source alongside `.env` and env vars |
| `Jenkins-User` header | Multi-tenant Basic auth support (alongside existing `Jenkins-Url` and `Jenkins-Token`) |
| Request timeout | 60s timeout on httpx client (was unlimited) |

## Backward Compatibility

- Multi-tenant header-based auth is preserved (stdio vs network mode)
- If no `jenkins_user` / `Jenkins-User` is provided, falls back to Bearer token auth
- `.env` file support via `python-dotenv` is preserved
- All existing tool functionality is maintained (tool names changed from camelCase to snake_case per Python convention)

Made with [Cursor](https://cursor.com)